### PR TITLE
Fix issue from 185: aws-code-deploy fails to check the existence of deployment group with extra arguments passed

### DIFF
--- a/src/commands/create-deployment-group.yml
+++ b/src/commands/create-deployment-group.yml
@@ -20,7 +20,11 @@ parameters:
       "The service role for a deployment group."
     type: string
   arguments:
-    description: If you wish to pass any additional arguments to the aws deploy command
+    description: If you wish to pass any additional arguments to the create-deployment-group command
+    type: string
+    default: ''
+  get-deployment-group-arguments:
+    description: If you wish to pass any additional arguments to the get-deployment-group command
     type: string
     default: ''
 steps:
@@ -30,7 +34,7 @@ steps:
         set +e
         aws deploy get-deployment-group \
           --application-name << parameters.application-name >> \
-          --deployment-group-name << parameters.deployment-group >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
+          --deployment-group-name << parameters.deployment-group >><<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>
         if [ $? -ne 0 ]; then
           set -e
           echo "No deployment group named << parameters.deployment-group >> found. Trying to create a new one"

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -42,6 +42,10 @@ parameters:
     description: If you wish to pass any additional arguments to the aws deploy command
     type: string
     default: ''
+  get-deployment-group-arguments:
+    description: If you wish to pass any additional arguments to the get-deployment-group command
+    type: string
+    default: ''
 executor: aws-cli/default
 steps:
   - checkout
@@ -54,6 +58,7 @@ steps:
       deployment-group: << parameters.deployment-group >>
       deployment-config: << parameters.deployment-config >>
       service-role-arn: << parameters.service-role-arn >>
+      get-deployment-group-arguments: << parameters.get-deployment-group-arguments >>
       arguments: << parameters.arguments >>
   - push-bundle:
       application-name: << parameters.application-name >>


### PR DESCRIPTION

Original issue from old repo: https://github.com/CircleCI-Public/circleci-orbs/issues/185
Original PR: https://github.com/CircleCI-Public/circleci-orbs/pull/235
Original reporter: @pcwiek
Original PR author: @Kobin

---

### What happened

Any arguments passed to `aws-code-deploy/create-deployment-group` which are intended for group creation are also passed to AWS CLI when calling `aws deploy get-deployment-group`, which makes the check for group existence fail each and every time because those options are not recognized by `get-deployment-group`. Then the step tries to create the group again and fails every time because the deployment group with specified name already exists.

`CIRCLE_WORKFLOW_ID=cf22d16d-2421-4a55-9ae0-2327f7b11fd6`

Example below is adapted from one of the steps from workflow above

**`ensure-deployment-created`**
```
set +e
aws deploy get-deployment-group \
  --application-name my-app \
  --deployment-group-name test --ec2-tag-filters Key=environment,Value=test,Type=KEY_AND_VALUE --auto-rollback-configuration enabled=true,events=DEPLOYMENT_FAILURE
if [ $? -ne 0 ]; then
  set -e
  echo "No deployment group named test found. Trying to create a new one"
  aws deploy create-deployment-group \
    --application-name my-app \
    --deployment-group-name test \
    --deployment-config-name CodeDeployDefault.OneAtATime \
    --service-role-arn $CODEDEPLOY_ROLE_ARN --ec2-tag-filters Key=environment,Value=test,Type=KEY_AND_VALUE --auto-rollback-configuration enabled=true,events=DEPLOYMENT_FAILURE
else
  set -e
  echo "Deployment group named test already exists. Skipping creation."
fi
```
Output:

```
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: --ec2-tag-filters, Key=environment,Value=test,Type=KEY_AND_VALUE, --auto-rollback-configuration, enabled=true,events=DEPLOYMENT_FAILURE, 
No deployment group named test found. Trying to create a new one

An error occurred (DeploymentGroupAlreadyExistsException) when calling the CreateDeploymentGroup operation: An Deployment Group with the name test already exists for this application.
Exited with code 255
```

### Expected behavior

Either the arguments should be split in two (arguments to `get-deployment-group` and `create-deployment-group` separately), or they should be only used for `create-deployment-group` and omitted for `get-deployment-group` call.

---

Fixes #185 
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Issue #185 showed that the arguments are passed both to the `get-deployment-group` and `create-deployment-group` subcommands. As the former has less arguments, it will likely fail when some arguments provided.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Separate `get-deployment-group` arguments into their own parameter, to ensure the command won't yield a non-zero exit code and trigger the deployment group creation just because the parameters were invalid.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->


---

@KyleTryon: I have taken your PR one step further to ensure the parameter is included within the deploy job, not just the command.

A concern I have is the arguments parameter is still passed to each command. Might that mean that similar issues to yours will still exist? @lokst I am wondering your thoughts, perhaps we need to break up arguments for each individual CLI command?