### PR TITLE
added aws cli parameter argument

### DIFF
--- a/src/commands/create-application.yml
+++ b/src/commands/create-application.yml
@@ -2,6 +2,11 @@
 description: >
   Creates an application.
 parameters:
+  profile-name:
+    description:
+      "The name of an AWS profile to use with aws-cli commands"
+    type: string
+    default: 'default'
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -15,11 +20,13 @@ steps:
       name: ensure-application-created
       command: |
         set +e
-        aws deploy get-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
+        aws --profile-name << parameters.profile-name >> \
+            deploy get-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
         if [ $? -ne 0 ]; then
           set -e
           echo "No application named << parameters.application-name >> found. Trying to create a new one"
-          aws deploy create-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
+          aws --profile-name << parameters.profile-name >> \
+              deploy create-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
         else
           set -e
           echo "Application named << parameters.application-name >> already exists. Skipping creation."

--- a/src/commands/create-deployment-group.yml
+++ b/src/commands/create-deployment-group.yml
@@ -2,6 +2,11 @@
 description: |
   Creates a deployment group to which application revisions are deployed.
 parameters:
+  profile-name:
+    description:
+      "The name of an AWS profile to use with aws-cli commands"
+    type: string
+    default: 'default'
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -32,14 +37,16 @@ steps:
       name: ensure-deployment-created
       command: |
         set +e
-        aws deploy get-deployment-group \
+        aws --profile-name << parameters.profile-name >> \
+          deploy get-deployment-group \
           --application-name << parameters.application-name >> \
           --deployment-group-name << parameters.deployment-group >><<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>
 
         if [ $? -ne 0 ]; then
           set -e
           echo "No deployment group named << parameters.deployment-group >> found. Trying to create a new one"
-          aws deploy create-deployment-group \
+          aws --profile-name << parameters.profile-name >> \
+            deploy create-deployment-group \
             --application-name << parameters.application-name >> \
             --deployment-group-name << parameters.deployment-group >> \
             --deployment-config-name << parameters.deployment-config >> \

--- a/src/commands/deploy-bundle.yml
+++ b/src/commands/deploy-bundle.yml
@@ -1,6 +1,11 @@
 description: |
   Deploy from a bundle and wait until the deployment has successfully completed.
 parameters:
+  profile-name:
+    description:
+      "The name of an AWS profile to use with aws-cli commands"
+    type: string
+    default: 'default'
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -40,20 +45,23 @@ steps:
   - run:
       name: deploy-bundle
       command: |
-        ID=$(aws deploy create-deployment \
+        ID=$(aws --profile-name << parameters.profile-name >> \
+                deploy create-deployment \
                 --application-name << parameters.application-name >> \
                 --deployment-group-name << parameters.deployment-group >> \
                 --deployment-config-name << parameters.deployment-config >> \
                 --s3-location bucket=<< parameters.bundle-bucket >>,bundleType=<< parameters.bundle-type >>,key=<< parameters.bundle-key >>.<< parameters.bundle-type >> \
                 --output text \
                 --query '[deploymentId]'<<# parameters.deploy-bundle-arguments >> << parameters.deploy-bundle-arguments >><</parameters.deploy-bundle-arguments >>)
-        STATUS=$(aws deploy get-deployment \
+        STATUS=$(aws --profile-name << parameters.profile-name >> \
+                  deploy get-deployment \
                   --deployment-id $ID \
                   --output text \
                   --query '[deploymentInfo.status]'<<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>)
         while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending" || $STATUS == "Queued" || $STATUS == "Ready" ]]; do
           echo "Status: $STATUS..."
-          STATUS=$(aws deploy get-deployment \
+          STATUS=$(aws --profile-name << parameters.profile-name >> \
+                    deploy get-deployment \
                     --deployment-id $ID \
                     --output text \
                     --query '[deploymentInfo.status]'<<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>)
@@ -66,5 +74,6 @@ steps:
           EXITCODE=1
           echo "Deployment failed!"
         fi
-        aws deploy get-deployment --deployment-id $ID<<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>
+        aws --profile-name << parameters.profile-name >> \
+            deploy get-deployment --deployment-id $ID<<# parameters.get-deployment-group-arguments >> << parameters.get-deployment-group-arguments >><</parameters.get-deployment-group-arguments >>
         exit $EXITCODE

--- a/src/commands/push-bundle.yml
+++ b/src/commands/push-bundle.yml
@@ -1,6 +1,11 @@
 description: |
   Bundles and uploads to Amazon Simple Storage Service (Amazon S3) an application revision
 parameters:
+  profile-name:
+    description:
+      "The name of an AWS profile to use with aws-cli commands"
+    type: string
+    default: 'default'
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -31,7 +36,8 @@ steps:
   - run:
       name: push-bundle
       command: |
-        aws deploy push \
+        aws --profile-name << parameters.profile-name >> \
+          deploy push \
           --application-name << parameters.application-name >> \
           --source << parameters.bundle-source >> \
           --s3-location s3://<< parameters.bundle-bucket >>/<< parameters.bundle-key >>.<< parameters.bundle-type >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>

--- a/src/examples/override_credentials.yml
+++ b/src/examples/override_credentials.yml
@@ -9,9 +9,9 @@ usage:
     deploy_application:
       jobs:
         - aws-code-deploy/deploy:
+            application-name: assume_role
             application-name: myApplication
             deployment-group: myDeploymentGroup
             service-role-arn: myDeploymentGroupRoleARN
             bundle-bucket: myApplicationS3Bucket
             bundle-key: myS3BucketKey
-            arguments: '--profile assume_role'

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -3,6 +3,11 @@ description:
        bundle and upload an application revision to S3. Once uploaded this
        job will finally create a deployment based on that revision."
 parameters:
+  profile-name:
+    description:
+      "The name of an AWS profile to use with aws-cli commands"
+    type: string
+    default: 'default'
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -55,9 +60,11 @@ steps:
   - checkout
   - aws-cli/setup
   - create-application:
+      profile-name: << parameters.profile-name >>
       application-name: << parameters.application-name >>
       arguments: << parameters.arguments >>
   - create-deployment-group:
+      profile-name: << parameters.profile-name >>
       application-name: << parameters.application-name >>
       deployment-group: << parameters.deployment-group >>
       deployment-config: << parameters.deployment-config >>
@@ -65,6 +72,7 @@ steps:
       get-deployment-group-arguments: << parameters.get-deployment-group-arguments >>
       arguments: << parameters.arguments >>
   - push-bundle:
+      profile-name: << parameters.profile-name >>
       application-name: << parameters.application-name >>
       bundle-source: << parameters.bundle-source >>
       bundle-bucket: << parameters.bundle-bucket >>
@@ -72,6 +80,7 @@ steps:
       bundle-type: << parameters.bundle-type >>
       arguments: << parameters.arguments >>
   - deploy-bundle:
+      profile-name: << parameters.profile-name >>
       application-name: << parameters.application-name >>
       deployment-group: << parameters.deployment-group >>
       deployment-config: << parameters.deployment-config >>


### PR DESCRIPTION
This is potential fix for #12 - I haven't tested it even by integration tests as I have no setup ready to do the tests - if you could push it through your AWS environment to get tested, I'd appreciate it.

I have added `profile-name` parameter to all commands and jobs in the orb as current way to pass it with `argument` parameter didn't work properly - not all `aws` executions in commands had `argument` passed, so it was sort of problematic.

Signed-off-by: Jan Tymiński <jan.tyminski@netguru.com>