### PR TITLE
docs: update deploy_application usage example 

### DIFF
--- a/src/examples/deploy_application.yml
+++ b/src/examples/deploy_application.yml
@@ -3,12 +3,17 @@ description: >
 usage:
   version: 2.1
   orbs:
-    aws-code-deploy: circleci/aws-code-deploy@x.y
+    aws-code-deploy: circleci/aws-code-deploy@dev:<<pipeline.git.revision>>
+    # import aws-cli orb to install and configure authentication
+    aws-cli: circleci/aws-cli@3.1
 
   workflows:
     deploy_application:
       jobs:
         - aws-code-deploy/deploy:
+            pre-steps:
+              # install and configure aws credentials with static keys stored as env_vars
+              - aws-cli/setup
             application-name: myApplication
             deployment-group: myDeploymentGroup
             service-role-arn: myDeploymentGroupRoleARN

--- a/src/examples/deploy_application.yml
+++ b/src/examples/deploy_application.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    aws-code-deploy: circleci/aws-code-deploy@dev:<<pipeline.git.revision>>
+    aws-code-deploy: circleci/aws-code-deploy@x.y
     # import aws-cli orb to install and configure authentication
     aws-cli: circleci/aws-cli@3.1
 

--- a/src/examples/deploy_application.yml
+++ b/src/examples/deploy_application.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    aws-code-deploy: circleci/aws-code-deploy@x.y
+    aws-code-deploy: circleci/aws-code-deploy@3.0
     # import aws-cli orb to install and configure authentication
     aws-cli: circleci/aws-cli@3.1
 


### PR DESCRIPTION
This `PR` updates the `deplot_application` usage example. The `deploy` job removes the `aws-cli/setup` step, which installs the `aws cli` and configures authentication using static `aws` keys stored as environment variables in `CircleCI`. 

Since the step is not longer available in the job, this example demonstrates the use of the `aws-cli/setup` step in a `workflow` as `pre-step` in a job.

