### PR TITLE
feat!/auth-step- parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,19 +12,24 @@ jobs:
       - image: cimg/python:3.10.7
     steps:
       - checkout
+      - aws-cli/setup:
+          role-arn: "arn:aws:iam::122211685980:role/CPE_CODE_DEPLOY_OIDC_TEST"
+          profile-name: OIDC-User
       - run:
           name: Start Instance
-          command: aws ec2 start-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION"
+          command: aws ec2 start-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION" --profile "OIDC-User"
       - aws-code-deploy/push-bundle:
           application-name: CodeDeployOrb_App
           bundle-source: ./sample_app
           bundle-bucket: aws-codedeploy-orb-test
           bundle-key: SampleApp_Linux
+          profile-name: OIDC-User
       - aws-code-deploy/deploy-bundle:
           application-name: CodeDeployOrb_App
           deployment-group: CodeDeployOrb_App_Group
           bundle-bucket: aws-codedeploy-orb-test
           bundle-key: SampleApp_Linux
+          profile-name: OIDC-User
       - run:
           name: Shutdown Instance
           command: aws ec2 stop-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION"
@@ -34,8 +39,6 @@ workflows:
       - integration-test:
           context: CPE-OIDC
           pre-steps:
-            - aws-cli/setup:
-               role-arn: "arn:aws:iam::122211685980:role/CPE_CODE_DEPLOY_OIDC_TEST"
           filters: *filters
       - orb-tools/pack:
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,16 +30,30 @@ jobs:
           bundle-bucket: aws-codedeploy-orb-test
           bundle-key: SampleApp_Linux
           profile-name: OIDC-User
-      - run:
-          name: Shutdown Instance
-          command: aws ec2 stop-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION"
 workflows:
   test-deploy:
     jobs:
-      - integration-test:
+      # - integration-test:
+      #     context: CPE-OIDC
+      #     filters: *filters
+      - aws-code-deploy/deploy:
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_CODE_DEPLOY_OIDC_TEST
+                role-session-name: "Test-session"
+                profile-name: "OIDC-User"
+          profile-name: OIDC-User
+          application-name: CodeDeployOrb_App
+          deployment-group: CodeDeployOrb_App_Group
+          service-role-arn: arn:aws:iam::122211685980:role/CodeDeployServiceRole
+          bundle-source: ./sample_app
+          bundle-bucket: aws-codedeploy-orb-test
+          bundle-key: SampleApp_Linux
           context: CPE-OIDC
-          pre-steps:
-          filters: *filters
+          post-steps:
+            - run: aws ec2 stop-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION" --profile "OIDC-User"
+          # requires:
+          #   - integration-test
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -48,7 +62,8 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - integration-test
+            # - integration-test
+            - aws-code-deploy/deploy
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,7 +9,7 @@ filters: &filters
 jobs:
   integration-test:
     docker:
-      - image: cimg/python:3.10.7
+      - image: cimg/aws:2023.03
     steps:
       - checkout
       - aws-cli/setup:
@@ -33,9 +33,9 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # - integration-test:
-      #     context: CPE-OIDC
-      #     filters: *filters
+      - integration-test:
+          context: CPE-OIDC
+          filters: *filters
       - aws-code-deploy/deploy:
           auth:
             - aws-cli/setup:
@@ -52,8 +52,8 @@ workflows:
           context: CPE-OIDC
           post-steps:
             - run: aws ec2 stop-instances --instance-ids "$AWS_CD_EC2_ID" --region "$AWS_DEFAULT_REGION" --profile "OIDC-User"
-          # requires:
-          #   - integration-test
+          requires:
+            - integration-test
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -62,7 +62,7 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            # - integration-test
+            - integration-test
             - aws-code-deploy/deploy
           context: orb-publisher
           filters:

--- a/src/examples/deploy_application.yml
+++ b/src/examples/deploy_application.yml
@@ -1,18 +1,18 @@
 description: >
-  Deploy an application to AWS CodeDeploy
+  Deploy an application to AWS CodeDeploy using static AWS keys for authentication
 usage:
   version: 2.1
   orbs:
     aws-code-deploy: circleci/aws-code-deploy@3.0
-    # import aws-cli orb to install and configure authentication
+    # Importing aws-cli orb is required for authentication
     aws-cli: circleci/aws-cli@3.1
 
   workflows:
     deploy_application:
       jobs:
         - aws-code-deploy/deploy:
-            pre-steps:
-              # install and configure aws credentials with static keys stored as env_vars
+            auth:
+              # Configure aws credentials with static keys stored as env_vars (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
               - aws-cli/setup
             application-name: myApplication
             deployment-group: myDeploymentGroup

--- a/src/examples/deploy_application_with_oidc.yml
+++ b/src/examples/deploy_application_with_oidc.yml
@@ -1,18 +1,18 @@
 description: >
-  Deploy an application to AWS CodeDeploy with OIDC authentication
+  Deploy an application to AWS CodeDeploy using OIDC authentication
 usage:
   version: 2.1
   orbs:
     aws-code-deploy: circleci/aws-code-deploy@3.0
-    # import aws-cli orb to install and configure OIDC authentication
+    # Importing aws-cli orb is required for OIDC authentication
     aws-cli: circleci/aws-cli@3.1
 
   workflows:
     deploy_application:
       jobs:
         - aws-code-deploy/deploy:
-            pre-steps:
-              # install aws cli and authenticate with OIDC
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
               - aws-cli/setup:
                   profile: "OIDC-USER"
                   role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_CODEDEPLOY_ROLE"
@@ -21,7 +21,7 @@ usage:
             service-role-arn: myDeploymentGroupRoleARN
             bundle-bucket: myApplicationS3Bucket
             bundle-key: myS3BucketKey
-            # must use same profile configured in aws-cli/setup command
+            # Must use same profile configured in aws-cli/setup command
             profile: "OIDC-USER"
             # must use valid CircleCI context for OIDC authentication
             context: CircleCI_OIDC_Token

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -1,10 +1,8 @@
 description: >
-  "Ensures an application and deployment group exist then proceeds to
+  Ensures an application and deployment group exist then proceeds to
     bundle and upload an application revision to S3. Once uploaded this
-    job will finally create a deployment based on that revision."
+    job will finally create a deployment based on that revision.
 parameters:
-  executor:
-    type: executor
   application-name:
     description:
       "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
@@ -62,7 +60,7 @@ parameters:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
-    type: steps    
+    type: steps
   region:
     type: string
     default: ${AWS_DEFAULT_REGION}

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -58,14 +58,21 @@ parameters:
       "The name of an AWS profile to use with aws-cli commands"
     type: string
     default: 'default'
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps    
   region:
     type: string
     default: ${AWS_DEFAULT_REGION}
     description: >
       AWS region of CodeDeploy App. Defaults to environment variable ${AWS_DEFAULT_REGION}.
-executor: << parameters.executor >>
+docker:
+  - image: cimg/aws:2023.03
 steps:
   - checkout
+  - steps: << parameters.auth >>
   - create-application:
       application-name: << parameters.application-name >>
       arguments: << parameters.arguments >>


### PR DESCRIPTION
This `PR` adds the `auth` parameter to the `deploy` job, requiring users to customize their authentication method by importing the `aws-cli` orb and using the `aws-cli/setup` command to authenticate using static AWS keys or a valid `role-arn` for OIDC.