### PR TITLE
feat: improve deployment config name parameter

### DIFF
--- a/src/commands/deploy_bundle.yml
+++ b/src/commands/deploy_bundle.yml
@@ -12,9 +12,8 @@ parameters:
   deployment_config:
     description:
       "Predefined deployment configuration name."
-    type: enum
-    enum: [ CodeDeployDefault.OneAtATime, CodeDeployDefault.HalfAtATime, CodeDeployDefault.AllAtOnce ]
-    default: "CodeDeployDefault.OneAtATime"
+    type: string
+    default: ''
   bundle_bucket:
     description:
       "The s3 bucket where an application revision will be stored"

--- a/src/scripts/deploy_bundle.sh
+++ b/src/scripts/deploy_bundle.sh
@@ -8,15 +8,25 @@ ORB_STR_GET_DEPLOYMENT_GROUP_ARGUMENTS="$(circleci env subst "${ORB_STR_GET_DEPL
 ORB_STR_BUNDLE_TYPE="$(circleci env subst "${ORB_STR_BUNDLE_TYPE}")"
 ORB_STR_DEPLOY_BUNDLE_ARGUMENTS="$(circleci env subst "${ORB_STR_DEPLOY_BUNDLE_ARGUMENTS}")"
 
-if [ -n "${ORB_STR_GET_DEPLOYMENT_GROUP_ARGUMENTS}" ]; then 
+if [ -n "${ORB_STR_GET_DEPLOYMENT_GROUP_ARGUMENTS}" ]; then
   set -- "$@" "${ORB_STR_GET_DEPLOYMENT_GROUP_ARGUMENTS}"
 fi
 
 if [ -n "${ORB_STR_DEPLOY_BUNDLE_ARGUMENTS}" ]; then
   set -- "$@" "${ORB_STR_DEPLOY_BUNDLE_ARGUMENTS}"
-fi 
+fi
 
-ID=$(aws deploy create-deployment \
+if [ -z ${ORB_STR_DEPLOYMENT_CONFIG+} ]; then
+  ID=$(aws deploy create-deployment \
+    --application-name "${ORB_STR_APPLICATION_NAME}" \
+    --deployment-group-name "${ORB_STR_DEPLOYMENT_GROUP}" \
+    --region "${ORB_STR_REGION}" \
+    --s3-location bucket="${ORB_STR_BUNDLE_BUCKET}",bundleType="${ORB_STR_BUNDLE_TYPE}",key="${ORB_STR_BUNDLE_KEY}"."${ORB_STR_BUNDLE_TYPE}" \
+    --profile "${ORB_STR_PROFILE_NAME}" \
+    --output text \
+    --query '[deploymentId]' "${ORB_STR_DEPLOY_BUNDLE_ARGUMENTS}")
+else
+  ID=$(aws deploy create-deployment \
     --application-name "${ORB_STR_APPLICATION_NAME}" \
     --deployment-group-name "${ORB_STR_DEPLOYMENT_GROUP}" \
     --deployment-config-name "${ORB_STR_DEPLOYMENT_CONFIG}" \
@@ -25,6 +35,7 @@ ID=$(aws deploy create-deployment \
     --profile "${ORB_STR_PROFILE_NAME}" \
     --output text \
     --query '[deploymentId]' "${ORB_STR_DEPLOY_BUNDLE_ARGUMENTS}")
+fi
 STATUS=$(aws deploy get-deployment \
     --deployment-id "$ID" \
     --output text \


### PR DESCRIPTION
Change the parameter type in order to support other compute platforms than EC2.

See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html

Make the parameter not required, so the valued configured in the deployment group is used.

See https://docs.aws.amazon.com/cli/latest/reference/deploy/create-deployment.html