### PR TITLE
Add CircleCI deploy markers support

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,3 +6,6 @@ description: >
 display:
   home_url: "https://aws.amazon.com/codedeploy/"
   source_url: "https://github.com/CircleCI-Public/aws-code-deploy-orb"
+
+orbs:
+  deploys: circleci/deploys@1.0

--- a/src/examples/deploy_application.yml
+++ b/src/examples/deploy_application.yml
@@ -1,6 +1,9 @@
-description: >
+description: |
   Deploy an application to AWS CodeDeploy using static AWS keys for authentication.
   Import the aws-cli orb and authenticate using the aws-cli/setup command with static AWS keys stored as env_vars (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).
+  Deploy markers are enabled by default (PLAN_AND_UPDATE mode): a CircleCI deploy marker is created before the deploy,
+  marked as running when it starts, and automatically updated to success or failed when the job completes.
+  The target version defaults to the short commit SHA and is shown in the CircleCI Deploys UI.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/deploy_application_with_deploy_markers.yml
+++ b/src/examples/deploy_application_with_deploy_markers.yml
@@ -1,0 +1,59 @@
+description: >
+  Deploy an application to AWS CodeDeploy with CircleCI deploy markers.
+  Four modes are available via the deploy_markers_mode parameter:
+    OFF             - no deploy markers
+    LOG             - log a deployment event after the CodeDeploy deployment completes
+    PLAN            - create a planned marker before the deployment; caller manages status updates
+    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-code-deploy: circleci/aws-code-deploy@4.0
+    aws-cli: circleci/aws-cli@4.0
+
+  workflows:
+    deploy:
+      jobs:
+        # LOG mode — log a deployment event after the CodeDeploy deployment completes
+        - aws-code-deploy/deploy:
+            name: deploy-log
+            application_name: my-app
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_mode: LOG
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        - aws-code-deploy/deploy:
+            name: deploy-plan
+            application_name: my-app
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_mode: PLAN
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb
+        - aws-code-deploy/deploy:
+            name: deploy-full
+            application_name: my-app
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_mode: PLAN_AND_UPDATE
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}

--- a/src/examples/deploy_application_with_deploy_markers.yml
+++ b/src/examples/deploy_application_with_deploy_markers.yml
@@ -1,10 +1,18 @@
 description: >
-  Deploy an application to AWS CodeDeploy with CircleCI deploy markers.
-  Four modes are available via the deploy_markers_mode parameter:
-    OFF             - no deploy markers
-    LOG             - log a deployment event after the CodeDeploy deployment completes
-    PLAN            - create a planned marker before the deployment; caller manages status updates
-    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
+  Deploy an application to AWS CodeDeploy with CircleCI deploy markers (enabled by default via PLAN_AND_UPDATE mode).
+  The default PLAN_AND_UPDATE lifecycle creates a planned marker before the deploy, marks it as
+  running when the deploy starts, and automatically sets it to success or failed when the job
+  completes — no extra configuration required.
+
+  This example shows the optional parameters available to customize deploy marker behavior:
+    deploy_markers_target_version  - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
+    deploy_markers_deploy_name     - unique identifier for this deployment; defaults to the workflow job ID,
+                                     which is already unique per execution, but can be set explicitly for
+                                     a more readable name in the CircleCI Deploys UI
+    deploy_markers_mode            - override the default PLAN_AND_UPDATE mode when needed:
+                                       LOG             - log a deployment event after the deploy (no planned marker)
+                                       PLAN            - create a planned marker before deploy; caller manages status updates
+                                       OFF             - disable deploy markers entirely
 
 usage:
   version: 2.1
@@ -16,7 +24,45 @@ usage:
   workflows:
     deploy:
       jobs:
-        # LOG mode — log a deployment event after the CodeDeploy deployment completes
+        # Default usage — deploy markers are on (PLAN_AND_UPDATE), target version defaults to short commit SHA
+        - aws-code-deploy/deploy:
+            name: deploy-app
+            application_name: my-app
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # Multiple deploys in the same workflow — optionally set deploy_markers_deploy_name for clearer identification
+        - aws-code-deploy/deploy:
+            name: deploy-app-a
+            application_name: my-app-a
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-a-bundle
+            deploy_markers_target_version: '${CIRCLE_SHA1}'
+            deploy_markers_deploy_name: deploy-app-a
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+        - aws-code-deploy/deploy:
+            name: deploy-app-b
+            application_name: my-app-b
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-b-bundle
+            deploy_markers_target_version: '${CIRCLE_SHA1}'
+            deploy_markers_deploy_name: deploy-app-b
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # LOG mode — records a deployment event after the deploy completes; no planned marker is created
         - aws-code-deploy/deploy:
             name: deploy-log
             application_name: my-app
@@ -25,35 +71,19 @@ usage:
             bundle_bucket: my-app-s3-bucket
             bundle_key: my-app-bundle
             deploy_markers_mode: LOG
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
             auth:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}
 
-        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        # Opting out — disable deploy markers with deploy_markers_mode: OFF
         - aws-code-deploy/deploy:
-            name: deploy-plan
+            name: deploy-no-markers
             application_name: my-app
             deployment_group: my-deployment-group
             service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
             bundle_bucket: my-app-s3-bucket
             bundle_key: my-app-bundle
-            deploy_markers_mode: PLAN
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
-            auth:
-              - aws-cli/setup:
-                  role_arn: ${AWS_ROLE_ARN}
-
-        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb
-        - aws-code-deploy/deploy:
-            name: deploy-full
-            application_name: my-app
-            deployment_group: my-deployment-group
-            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
-            bundle_bucket: my-app-s3-bucket
-            bundle_key: my-app-bundle
-            deploy_markers_mode: PLAN_AND_UPDATE
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            deploy_markers_mode: OFF
             auth:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}

--- a/src/examples/deploy_application_with_oidc.yml
+++ b/src/examples/deploy_application_with_oidc.yml
@@ -1,6 +1,9 @@
-description: >
+description: |
   Deploy an application to AWS CodeDeploy using OIDC authentication.
   Import the aws-cli orb and authenticate using the aws-cli/setup command with a valid role-arn for OIDC authentication.
+  Deploy markers are enabled by default (PLAN_AND_UPDATE mode): a CircleCI deploy marker is created before the deploy,
+  marked as running when it starts, and automatically updated to success or failed when the job completes.
+  The target version defaults to the short commit SHA and is shown in the CircleCI Deploys UI.
 usage:
   version: 2.1
   orbs:

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -61,6 +61,29 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
+  deploy_markers_mode:
+    description: >
+      Controls CircleCI deploy marker integration via the deploys orb.
+      OFF: no deploy markers are created.
+      LOG: logs a deployment event after the CodeDeploy deployment completes.
+      PLAN: creates a planned deployment marker before the deployment; status updates are left to the caller.
+      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after (default).
+    type: enum
+    enum: [OFF, LOG, PLAN, PLAN_AND_UPDATE]
+    default: PLAN_AND_UPDATE
+  deploy_markers_deploy_name:
+    description: >
+      Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
+      Must be unique if planning multiple deployments in the same workflow.
+      Defaults to the workflow job ID, which is unique per job execution across all concurrent runs.
+    type: string
+    default: "${CIRCLE_WORKFLOW_JOB_ID}"
+  deploy_markers_target_version:
+    description: >
+      Version identifier shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the short commit SHA if not set.
+    type: string
+    default: ""
   region:
     type: string
     default: ${AWS_DEFAULT_REGION}
@@ -74,6 +97,25 @@ executor: << parameters.executor >>
 steps:
   - checkout
   - steps: << parameters.auth >>
+  - when:
+      condition:
+        or:
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN"]
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/plan:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            component_name: << parameters.application_name >>
+            environment_name: << parameters.deployment_group >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: RUNNING
+            when: always
   - create_application:
       application_name: << parameters.application_name >>
       arguments: << parameters.arguments >>
@@ -108,3 +150,23 @@ steps:
       deploy_bundle_arguments: << parameters.deploy_bundle_arguments >>
       profile_name: << parameters.profile_name >>
       region: << parameters.region >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "LOG"]
+      steps:
+        - deploys/log:
+            component_name: << parameters.application_name >>
+            environment_name: << parameters.deployment_group >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: SUCCESS
+            when: on_success
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: FAILED
+            when: on_fail


### PR DESCRIPTION
## Summary

- Adds `deploys: circleci/deploys@1.0` orb dependency to `src/@orb.yml`
- Adds three new parameters to the `deploy` job: `deploy_markers_mode` (enum: `OFF`, `LOG`, `PLAN`, `PLAN_AND_UPDATE`; default `PLAN_AND_UPDATE`), `deploy_markers_deploy_name` (default `${CIRCLE_WORKFLOW_JOB_ID}`), and `deploy_markers_target_version`
- Inserts deploy marker steps around the deployment: plan/running before `deploy_bundle`, and log/success/failed after
- Adds `src/examples/deploy_application_with_deploy_markers.yml` showing all active modes

Mirrors the same pattern applied to `aws-ecs-orb` in [CircleCI-Public/aws-ecs-orb#feat/deploy-markers].

## Test plan

- [ ] Verify `OFF` mode produces no deploy marker steps
- [ ] Verify `LOG` mode emits a `deploys/log` step after `deploy_bundle`
- [ ] Verify `PLAN` mode emits `deploys/plan` before the deployment steps
- [ ] Verify `PLAN_AND_UPDATE` mode emits plan → running → success/failed around the deployment