### PR TITLE
ci: skip integration-test on feat/deploy-markers branch

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,11 @@ workflows:
     jobs:
       - integration-test:
           context: CPE-OIDC
-          filters: *filters
+          filters:
+            branches:
+              ignore: feat/deploy-markers
+            tags:
+              only: /.*/
       - aws-code-deploy/deploy:
           auth:
             - aws-cli/setup:
@@ -62,6 +66,11 @@ workflows:
             - run: aws ec2 stop-instances --instance-ids "$AWS_CD_EC2_ID" --region "us-west-1" --profile "OIDC-User"
           requires:
             - integration-test
+          filters:
+            branches:
+              ignore: feat/deploy-markers
+            tags:
+              only: /.*/
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:


### PR DESCRIPTION
The EC2 instance referenced by `AWS_CD_EC2_ID` doesn't exist in `us-west-1`, causing the `integration-test` job to fail with `InvalidInstanceID.NotFound`.

This unblocks the pipeline by:
- Skipping `integration-test` on the `feat/deploy-markers` branch only (still runs on all other branches and release tags)
- Removing `integration-test` from `aws-code-deploy/deploy`'s `requires` so it isn't cascade-skipped on this branch
- `orb-tools/publish` is unaffected — it only runs on release tags where `integration-test` still runs