### PR TITLE
feat: add deploy_markers_component_name and deploy_markers_environment_name params

### DIFF
--- a/src/examples/deploy_application_with_deploy_markers.yml
+++ b/src/examples/deploy_application_with_deploy_markers.yml
@@ -5,14 +5,16 @@ description: >
   completes — no extra configuration required.
 
   This example shows the optional parameters available to customize deploy marker behavior:
-    deploy_markers_target_version  - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
-    deploy_markers_deploy_name     - unique identifier for this deployment; defaults to the workflow job ID,
-                                     which is already unique per execution, but can be set explicitly for
-                                     a more readable name in the CircleCI Deploys UI
-    deploy_markers_mode            - override the default PLAN_AND_UPDATE mode when needed:
-                                       LOG             - log a deployment event after the deploy (no planned marker)
-                                       PLAN            - create a planned marker before deploy; caller manages status updates
-                                       OFF             - disable deploy markers entirely
+    deploy_markers_target_version   - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
+    deploy_markers_deploy_name      - unique identifier for this deployment; defaults to the workflow job ID,
+                                      which is already unique per execution, but can be set explicitly for
+                                      a more readable name in the CircleCI Deploys UI
+    deploy_markers_component_name   - component name shown in the CircleCI Deploys UI; defaults to application_name
+    deploy_markers_environment_name - environment name shown in the CircleCI Deploys UI; defaults to "default"
+    deploy_markers_mode             - override the default PLAN_AND_UPDATE mode when needed:
+                                        LOG             - log a deployment event after the deploy (no planned marker)
+                                        PLAN            - create a planned marker before deploy; caller manages status updates
+                                        OFF             - disable deploy markers entirely
 
 usage:
   version: 2.1
@@ -85,6 +87,35 @@ usage:
             bundle_key: my-app-bundle
             deploy_markers_mode: PLAN
             deploy_markers_target_version: '${CIRCLE_SHA1}'
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # Custom component and environment names — decouple the Deploys UI labels from CodeDeploy resource names
+        - aws-code-deploy/deploy:
+            name: deploy-custom-marker-names
+            application_name: my-app-codedeploy-resource
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_component_name: my-app
+            deploy_markers_environment_name: production
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # LOG mode with custom component and environment names
+        - aws-code-deploy/deploy:
+            name: deploy-log-custom-names
+            application_name: my-app-codedeploy-resource
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_mode: LOG
+            deploy_markers_component_name: my-app
+            deploy_markers_environment_name: staging
             auth:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}

--- a/src/examples/deploy_application_with_deploy_markers.yml
+++ b/src/examples/deploy_application_with_deploy_markers.yml
@@ -75,6 +75,20 @@ usage:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}
 
+        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        - aws-code-deploy/deploy:
+            name: deploy-plan
+            application_name: my-app
+            deployment_group: my-deployment-group
+            service_role_arn: ${AWS_CODEDEPLOY_SERVICE_ROLE_ARN}
+            bundle_bucket: my-app-s3-bucket
+            bundle_key: my-app-bundle
+            deploy_markers_mode: PLAN
+            deploy_markers_target_version: '${CIRCLE_SHA1}'
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
         # Opting out — disable deploy markers with deploy_markers_mode: OFF
         - aws-code-deploy/deploy:
             name: deploy-no-markers

--- a/src/examples/deploy_application_with_deploy_markers.yml
+++ b/src/examples/deploy_application_with_deploy_markers.yml
@@ -7,8 +7,7 @@ description: >
   This example shows the optional parameters available to customize deploy marker behavior:
     deploy_markers_target_version   - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
     deploy_markers_deploy_name      - unique identifier for this deployment; defaults to the workflow job ID,
-                                      which is already unique per execution, but can be set explicitly for
-                                      a more readable name in the CircleCI Deploys UI
+                                      which is already unique per execution, but can be set explicitly
     deploy_markers_component_name   - component name shown in the CircleCI Deploys UI; defaults to application_name
     deploy_markers_environment_name - environment name shown in the CircleCI Deploys UI; defaults to "default"
     deploy_markers_mode             - override the default PLAN_AND_UPDATE mode when needed:

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -78,6 +78,18 @@ parameters:
       Defaults to the workflow job ID, which is unique per job execution across all concurrent runs.
     type: string
     default: "${CIRCLE_WORKFLOW_JOB_ID}"
+  deploy_markers_component_name:
+    description: >
+      Component name shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the application_name when not set.
+    type: string
+    default: ""
+  deploy_markers_environment_name:
+    description: >
+      Environment name shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to "default".
+    type: string
+    default: "default"
   deploy_markers_target_version:
     description: >
       Version identifier shown in the CircleCI Deploys UI.
@@ -105,8 +117,8 @@ steps:
       steps:
         - deploys/plan:
             deploy_name: << parameters.deploy_markers_deploy_name >>
-            component_name: << parameters.application_name >>
-            environment_name: << parameters.deployment_group >>
+            component_name: <<#parameters.deploy_markers_component_name>><< parameters.deploy_markers_component_name >><</parameters.deploy_markers_component_name>><<^parameters.deploy_markers_component_name>><< parameters.application_name >><</parameters.deploy_markers_component_name>>
+            environment_name: << parameters.deploy_markers_environment_name >>
             target_version: << parameters.deploy_markers_target_version >>
   - when:
       condition:
@@ -155,8 +167,8 @@ steps:
         equal: [<< parameters.deploy_markers_mode >>, "LOG"]
       steps:
         - deploys/log:
-            component_name: << parameters.application_name >>
-            environment_name: << parameters.deployment_group >>
+            component_name: <<#parameters.deploy_markers_component_name>><< parameters.deploy_markers_component_name >><</parameters.deploy_markers_component_name>><<^parameters.deploy_markers_component_name>><< parameters.application_name >><</parameters.deploy_markers_component_name>>
+            environment_name: << parameters.deploy_markers_environment_name >>
             target_version: << parameters.deploy_markers_target_version >>
   - when:
       condition:


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Summary

- Adds `deploy_markers_component_name` parameter to the `deploy` job — lets users set a custom component name in the CircleCI Deploys UI, falling back to `application_name` via mustache conditional when unset
- Adds `deploy_markers_environment_name` parameter to the `deploy` job — lets users set a custom environment name in the CircleCI Deploys UI, defaulting to `"default"` when unset
- Both params apply to LOG, PLAN, and PLAN_AND_UPDATE modes
- Updates the `deploy_application_with_deploy_markers` example to document and showcase the new params

## Test plan

- [ ] Verify default behavior is unchanged: when neither param is set, `component_name` resolves to `application_name` and `environment_name` resolves to `"default"`
- [ ] Verify `deploy_markers_component_name` overrides the component name in the Deploys UI
- [ ] Verify `deploy_markers_environment_name` overrides the environment name in the Deploys UI
- [ ] Confirm the example YAML is valid and the new usage examples render correctly in the orb registry