### PR TITLE
Fix ORB_STR_BUNDLE_TYPE extension in push_bundle.sh

### DIFF
--- a/src/scripts/push_bundle.sh
+++ b/src/scripts/push_bundle.sh
@@ -5,6 +5,7 @@ ORB_STR_BUNDLE_KEY="$(circleci env subst "${ORB_STR_BUNDLE_KEY}")"
 ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
 ORB_STR_ARGUMENTS="$(circleci env subst "${ORB_STR_ARGUMENTS}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
+ORB_STR_BUNDLE_TYPE="$(circleci env subst "${ORB_STR_BUNDLE_TYPE}")"
 ORB_EVAL_BUNDLE_SOURCE="$(eval echo "${ORB_EVAL_BUNDLE_SOURCE}")"
 
 if [ -n "${ORB_STR_ARGUMENTS}" ]; then 
@@ -16,4 +17,4 @@ aws deploy push \
     --source "${ORB_EVAL_BUNDLE_SOURCE}" \
     --profile "${ORB_STR_PROFILE_NAME}" \
     --region "${ORB_STR_REGION}" \
-    --s3-location s3://"${ORB_STR_BUNDLE_BUCKET}/${ORB_STR_BUNDLE_KEY}.${ORB_VAL_BUNDLE_TYPE}" "$@"
+    --s3-location s3://"${ORB_STR_BUNDLE_BUCKET}/${ORB_STR_BUNDLE_KEY}.${ORB_STR_BUNDLE_TYPE}" "$@"


### PR DESCRIPTION
The orb's push_bundle command references ORB_VAL_BUNDLE_TYPE in the
s3-location argument, but the env var is set as ORB_STR_BUNDLE_TYPE — causing
bundles to be uploaded with a trailing dot instead of the full extension.